### PR TITLE
Add shared Mac Platform SSO guide

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,10 @@ We value your contribution. We'd like to make it as easy as possible to submit
 your contributions to the Svetek docs repository. Changes to the docs are
 handled through pull requests against the `master` branch. 
 
+Before adding or renaming documentation pages, review the
+[SEO guidelines](SEO_GUIDELINES.md) for front matter, canonical URLs, redirects,
+images, and pre-publish checks.
+
 ## Copyright and license
 
 Copyright 2025 Svetek IT Experts, released under the Apache 2.0 license.
-

--- a/SEO_GUIDELINES.md
+++ b/SEO_GUIDELINES.md
@@ -1,0 +1,181 @@
+# SEO Guidelines for Svetek Documentation
+
+Use this guide when creating or updating pages in this repository. The goal is simple: every page should have a clear search intent, a stable canonical URL, useful search-result copy, and a clean social preview.
+
+## Quick checklist
+
+Before publishing a page, confirm:
+
+- The page answers one specific user need.
+- The URL slug is descriptive and stable.
+- Front matter includes `title`, `seo_title`, `description`, `keywords`, and `canonical`.
+- Open Graph fields are set for important pages: `og_title`, `og_description`, `og_type`, `og_image`, and `og_url`.
+- Twitter fields are set when the social preview should differ from Open Graph.
+- Images have descriptive alt text and live beside the page when possible.
+- Replaced or renamed pages keep redirects.
+- The page is linked from `_data/toc.yaml` if it should be discoverable in site navigation.
+
+## Recommended front matter
+
+Use this as the default template for new documentation pages:
+
+```yaml
+---
+title: "Human-Friendly Page Title"
+seo_title: "Primary Keyword Page Title | MSP Guide for Vancouver WA, Portland OR, Seattle WA"
+description: "One or two sentences explaining exactly what the page helps the reader do. Include the primary product, service, or problem. Keep this useful, not stuffed."
+keywords: "primary keyword, secondary keyword, product name, service area, IT support Vancouver WA, IT support Portland OR, IT support Seattle WA"
+canonical: https://help.svetek.com/docs/Category/Product/descriptive-page-slug/
+og_title: "Short Social Preview Title"
+og_description: "Short social preview description focused on the page's practical value."
+og_type: article
+og_image: https://help.svetek.com/docs/Category/Product/descriptive-page-slug/images/preview-image.png
+og_url: https://help.svetek.com/docs/Category/Product/descriptive-page-slug/
+published_time: 2026-06-26T00:00:00+00:00
+twitter_title: "Short Social Preview Title"
+twitter_description: "Short social preview description focused on the page's practical value."
+twitter_image: https://help.svetek.com/docs/Category/Product/descriptive-page-slug/images/preview-image.png
+twitter_image_alt: "Plain-language description of the preview image"
+redirect_from:
+  - /old/path/if-this-page-replaces-one/
+layout: docs
+---
+```
+
+## Field guidance
+
+- `title`: The on-page H1. Make it clear and human-readable.
+- `seo_title`: The browser/search title. Include the core topic and, where appropriate, service-area language.
+- `description`: Search-result summary. Describe the outcome or task, not just the product.
+- `keywords`: Keep a concise comma-separated list. Include product names, task terms, and local service terms when relevant.
+- `canonical`: Always set the production URL. Use `https://help.svetek.com/...` and include the trailing slash.
+- `og_title` and `og_description`: Social preview copy. Usually shorter than `seo_title` and `description`.
+- `og_type`: Use `article` for guides and manuals. Use `website` for section indexes.
+- `og_image`: Use an absolute `https://help.svetek.com/...` URL to a relevant image.
+- `og_url`: Usually matches `canonical`.
+- `published_time`: Use ISO-like timestamps, for example `2026-06-26T00:00:00+00:00`.
+- `twitter_*`: Use when the Twitter/X preview should be explicit. If omitted, the shared head template falls back to Open Graph and standard SEO values.
+- `redirect_from`: Add old URLs when replacing, renaming, or consolidating pages.
+
+## Titles and descriptions
+
+Good titles are specific:
+
+- Good: `Provisioning M365 Users in 3CX with Entra ID SSO`
+- Good: `Configure 3CX IP Phones with Fanvil Auto-Provisioning`
+- Avoid: `3CX Setup`
+- Avoid: `Microsoft Guide`
+
+Good descriptions explain the job-to-be-done:
+
+- Good: `Step-by-step guide for provisioning Microsoft 365 users into a 3CX PBX configured with Entra ID SSO, including replacement user workflows.`
+- Avoid: `This page explains 3CX.`
+
+Keep titles readable. Do not repeat every city or keyword in every field. The `seo_title`, `description`, and `keywords` fields are enough for local-service context when it is relevant.
+
+## URL slugs
+
+Use lowercase descriptive slugs with hyphens:
+
+- Good: `/docs/Configuration/3CX/3cx-m365-user-provisioning-entra-sso/`
+- Good: `/docs/Configuration/3CX/configure-3cx-ip-phones-fanvil-provisioning/`
+- Avoid: `/docs/Configuration/3CX/new-page/`
+- Avoid: `/docs/Guides/Thing/index2/`
+
+When renaming an existing page, keep the old page as a redirect or add `redirect_from` to the new page.
+
+## Page structure
+
+Most guides should follow this shape:
+
+1. Overview: who the guide is for and what it accomplishes.
+2. Prerequisites or assumptions.
+3. Step-by-step procedure.
+4. Verification steps.
+5. Common pitfalls or troubleshooting.
+6. Need Help section for Svetek support positioning.
+
+Use headings that match what users search for, such as `Configure Presence Sync`, `Assign the Physical Phone`, or `Common Pitfalls`.
+
+## Images
+
+Use images when they clarify a step or improve social previews.
+
+- Store page-specific images in an `images/` folder next to `index.md`.
+- Use descriptive filenames, such as `3cx-m365-users-sync.png`.
+- Use descriptive Markdown alt text.
+- Set `og_image` and `twitter_image` to the best representative screenshot.
+- Avoid dark, cropped, or ambiguous preview images when the screenshot should communicate a real UI state.
+
+Example:
+
+```markdown
+![3CX M365 Users sync configuration screen](images/3cx-m365-users-sync.png)
+```
+
+## Internal links and navigation
+
+Add a page to `_data/toc.yaml` when it should be reachable from the left navigation. Place it under the product or category users would naturally browse.
+
+When a page supersedes another page:
+
+- Point navigation to the new canonical page.
+- Keep the old URL as a redirect.
+- Add `redirect_from` aliases for likely historical slugs.
+
+## Redirect page template
+
+For an old page that should forward to a new canonical page:
+
+```yaml
+---
+title: "Old Page Title"
+layout: redirect
+redirect:
+  to: /docs/Configuration/3CX/new-canonical-page/
+---
+```
+
+## Local SEO notes
+
+Svetek pages can mention Vancouver WA, Portland OR, and Seattle WA when the page is relevant to managed IT, MSP, VoIP, Microsoft 365, security, or support services in those markets.
+
+Use local terms naturally:
+
+- In `seo_title` for important service pages.
+- In `description` when service availability matters.
+- In the final `Need Help` section.
+
+Do not force city names into every heading or paragraph.
+
+## Pre-publish checks
+
+Run a local build before publishing:
+
+```sh
+bundle exec jekyll build --config _config.yml,_config_production.yml
+```
+
+If local bundled gems cause Jekyll to crawl `vendor/`, use a temporary verification config:
+
+```sh
+printf '%s\n' 'exclude: ["_scripts", "404.html", "index.html", "vendor"]' > /private/tmp/svetek_jekyll_verify.yml
+bundle exec jekyll build --config _config.yml,_config_production.yml,/private/tmp/svetek_jekyll_verify.yml
+```
+
+Spot-check rendered metadata:
+
+```sh
+rg -n '<title>|canonical|og:title|og:description|og:image|twitter:title|twitter:image' _site/path/to/page/index.html
+```
+
+## Pull request checklist
+
+Use this checklist in documentation PRs:
+
+- Front matter follows the recommended template.
+- Canonical URL matches the final production path.
+- Old URLs redirect to the new page.
+- Page is linked from `_data/toc.yaml` when appropriate.
+- Screenshots render locally and have useful alt text.
+- Build passes.

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ incremental: true
 permalink: pretty
 safe: false
 lsi: false
-#exclude: ["_samples", "_scripts", "404.html", "datacenter", "ee", "index.html", "js/metadata.json"]
+exclude: ["Readme.md", "SEO_GUIDELINES.md"]
 
 # Component versions -- address like site.docker_ce_version
 # You can't have - characters in these for non-YAML reasons

--- a/_config_development.yml
+++ b/_config_development.yml
@@ -16,7 +16,7 @@ incremental: true
 permalink: pretty
 safe: false
 lsi: false
-exclude: ["_samples", "_scripts", "404.html", "datacenter", "ee", "index.html", "js/metadata.json"]
+exclude: ["_samples", "_scripts", "404.html", "datacenter", "ee", "index.html", "js/metadata.json", "Readme.md", "SEO_GUIDELINES.md"]
 
 # Component versions -- address like site.docker_ce_version
 # You can't have - characters in these for non-YAML reasons

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -5,7 +5,7 @@
 # Override the exclusion list to include files that are excluded in "development",
 # such as the "enterprise" stubs, which are in place to facilitate redirects
 # to Svetek.
-exclude: ["_scripts", "404.html", "index.html"]
+exclude: ["_scripts", "404.html", "index.html", "Readme.md", "SEO_GUIDELINES.md"]
 
 # Google Analytics, etc.
 google_analytics: G-V9CJQJRYMC

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -60,6 +60,8 @@ guides:
     section:
       - title: "Bring your own devices"
         path: /docs/Guides/Intune/Bring_your_own_device/
+      - title: "Add a user to a shared Mac with Platform SSO"
+        path: /docs/Guides/Intune/add-user-shared-mac-platform-sso/
       - title: "DUO MFA ENROLLMENT DEVICE"
         path: /docs/Guides/Intune/DUO_enrolment/
   - sectiontitle: Windows Virtual Desktop

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -73,7 +73,7 @@
         <div class="bottom_footer">
             <div class="footer-copyright col-xs-12 col-md-8">
                 <p class="copyright">
-                    Copyright &copy; 2013-2024 Svetek IT Experts. All rights reserved. </p>
+                    Copyright &copy; {{ site.time | date: "%Y" }} Svetek IT Experts. All rights reserved. </p>
             </div>
             <div class="footer_social_nav">
                 <ul class="nav-social">

--- a/docs/Guides/Intune/add-user-shared-mac-platform-sso/index.md
+++ b/docs/Guides/Intune/add-user-shared-mac-platform-sso/index.md
@@ -1,0 +1,113 @@
+---
+title: "Add a User to a Shared Mac with Platform SSO"
+seo_title: "Add a User to a Shared Mac with Platform SSO | Intune macOS Guide"
+description: "Step-by-step guide for adding a user to an Intune-managed shared Mac with Platform SSO enabled by pre-staging a local macOS account."
+keywords: "Intune shared Mac, macOS Platform SSO, Entra ID Platform SSO, pre-stage local account, macOS user provisioning, shared Mac login, IT support Vancouver WA, IT support Portland OR, IT support Seattle WA"
+canonical: https://help.svetek.com/docs/Guides/Intune/add-user-shared-mac-platform-sso/
+og_title: "Add a User to a Shared Mac with Platform SSO"
+og_description: "Pre-stage a local macOS account, complete first login, and register Platform SSO for an Intune-managed shared Mac."
+og_type: article
+og_image: https://help.svetek.com/images/logo_horizontal_whitetext.svg
+og_url: https://help.svetek.com/docs/Guides/Intune/add-user-shared-mac-platform-sso/
+published_time: 2026-06-26T00:00:00+00:00
+twitter_title: "Add a User to a Shared Mac with Platform SSO"
+twitter_description: "Pre-stage a local account and register Platform SSO for an Intune-managed shared Mac."
+twitter_image: https://help.svetek.com/images/logo_horizontal_whitetext.svg
+twitter_image_alt: "Svetek logo"
+layout: docs
+---
+
+# Add a User to a Shared Mac with Platform SSO
+
+Use the **pre-stage local account** method for Intune-managed shared Macs where Platform SSO is enabled.
+
+This guide is for Macs where login-window Entra provisioning is not working reliably. In that scenario, pre-staging the local macOS account first is the practical path. Each local user still needs to complete their own Platform SSO registration after reaching the desktop.
+
+## Prerequisites
+
+- Confirm the Mac is enrolled in Intune and has the Platform SSO configuration profile assigned.
+- Confirm you have a working local administrator account on the Mac.
+- Replace the example username, full name, temporary password, and Entra ID email address with the real user's details.
+- Use a temporary password that meets the organization's local macOS password requirements.
+
+## Add Another User Locally
+
+Log in as the local administrator and run:
+
+```bash
+sudo sysadminctl -addUser john -fullName "John Doe" -password 'Password123!'
+sudo pwpolicy -u john -setpolicy "newPasswordRequired=1"
+```
+
+The `sysadminctl` command above creates a standard local user. Do not add the `-admin` option unless the user should be a local administrator.
+
+## Verify the Local Account
+
+Verify the account:
+
+```bash
+id john
+dscl . -read /Users/john NFSHomeDirectory
+```
+
+Expected home directory:
+
+```text
+NFSHomeDirectory: /Users/john
+```
+
+Give the user the temporary Mac login details through an approved secure channel.
+
+## User First Login {#user-first-login}
+
+At the Mac login screen, sign in with the temporary local Mac account:
+
+```text
+Username: john
+Password: Password123!
+```
+
+macOS should prompt you to set a new **local Mac password**.
+
+After you reach the desktop, look for the Platform SSO registration prompt.
+
+If the registration prompt does not appear:
+
+1. Open **System Settings**.
+2. Go to **Users & Groups**.
+3. Open **Network Account Server**.
+4. Click **Register**.
+5. Sign in with your Entra account, for example:
+
+```text
+john@company.com
+```
+
+## Enable or Register Platform SSO
+
+Platform SSO registration connects the local Mac account to the user's Entra account. Registration is per user, so every local user on the shared Mac must complete this step.
+
+If the user has already reached the desktop but is not registered:
+
+1. Open **System Settings**.
+2. Go to **Users & Groups**.
+3. Open **Network Account Server**.
+4. Click **Register**.
+5. Have the user sign in with their Entra account.
+
+## Common Pitfalls
+
+- The local username must match the account created with `sysadminctl`; in this example, the username is `john`.
+- The temporary password is only for the local Mac account. The user still signs in with their Entra account during Platform SSO registration.
+- Platform SSO registration is per local user. Registering one user does not register every account on the shared Mac.
+- If the Platform SSO registration button is missing, confirm the Mac has received the Intune Platform SSO configuration profile.
+
+## Notes
+
+Apple's Platform SSO flow supports shared Macs with shared device keys and create-user-at-login. When login-window Entra provisioning is not working, pre-staging local accounts avoids relying on that provisioning path while still allowing each user to register Platform SSO after first login.
+
+Reference: [Apple Platform SSO for macOS](https://support.apple.com/guide/deployment/platform-sso-for-macos-dep7bbb05313/web)
+
+## Need Help
+
+Svetek can help organizations in Vancouver WA, Portland OR, and Seattle WA configure Intune-managed Macs, Platform SSO, and shared-device user workflows.


### PR DESCRIPTION
## Summary
- Add SEO guidelines for documentation pages
- Add Intune shared Mac Platform SSO guide using the pre-stage local account method
- Update navigation and site metadata/config/footer changes from the current worktree

## Validation
- bundle exec jekyll build --config _config.yml,_config_production.yml,/private/tmp/svetek_jekyll_verify.yml